### PR TITLE
check for an empty result in the ldap contexts

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -743,14 +743,14 @@ class auth_plugin_ldap_syncplus extends auth_plugin_ldap {
             }
 
             // If there is an error in the LDAP result,
-            // or the user was not found: continue with next context
+            // or the user was not found: continue with next context.
             if (!$ldapresult || ldap_count_entries($ldapconnection, $ldapresult) == 0)  {
                 continue;
             }
 
-            // If there is not exactly one matching user, we can't continue, call parent hook and return
+            // If there is not exactly one matching user, we can't continue, call parent hook and return.
             if (ldap_count_entries($ldapconnection, $ldapresult) != 1) {
-                parent::loginpage_hook(); // Call parent function to retain its functionality
+                parent::loginpage_hook(); // Call parent function to retain its functionality.
                 return;
             }
 

--- a/auth.php
+++ b/auth.php
@@ -736,7 +736,7 @@ class auth_plugin_ldap_syncplus extends auth_plugin_ldap {
             }
 
             // If there is an error in the LDAP result,
-	    // or the user was not found: continue with next context
+            // or the user was not found: continue with next context
             if (!$ldap_result || ldap_count_entries($ldapconnection, $ldap_result) == 0)  {
                 continue;
             }

--- a/auth.php
+++ b/auth.php
@@ -744,12 +744,12 @@ class auth_plugin_ldap_syncplus extends auth_plugin_ldap {
 
             // If there is an error in the LDAP result,
             // or the user was not found: continue with next context
-            if (!$ldap_result || ldap_count_entries($ldapconnection, $ldap_result) == 0)  {
+            if (!$ldapresult || ldap_count_entries($ldapconnection, $ldapresult) == 0)  {
                 continue;
             }
 
             // If there is not exactly one matching user, we can't continue, call parent hook and return
-            if (ldap_count_entries($ldapconnection, $ldap_result) != 1) {
+            if (ldap_count_entries($ldapconnection, $ldapresult) != 1) {
                 parent::loginpage_hook(); // Call parent function to retain its functionality
                 return;
             }

--- a/auth.php
+++ b/auth.php
@@ -741,9 +741,6 @@ class auth_plugin_ldap_syncplus extends auth_plugin_ldap {
                 continue;
             }
 
-            // Get users in LDAP result
-            $users = ldap_get_entries_moodle($ldapconnection, $ldap_result);
-
             // If there is not exactly one matching user, we can't continue, call parent hook and return
             if (ldap_count_entries($ldapconnection, $ldap_result) != 1) {
                 parent::loginpage_hook(); // Call parent function to retain its functionality

--- a/auth.php
+++ b/auth.php
@@ -735,8 +735,9 @@ class auth_plugin_ldap_syncplus extends auth_plugin_ldap {
                 $ldap_result = ldap_list($ldapconnection, $context, $filter, array($authplugin->config->user_attribute));
             }
 
-            // If there is no LDAP result, continue with next context
-            if (!$ldap_result) {
+            // If there is an error in the LDAP result,
+	    // or the user was not found: continue with next context
+            if (!$ldap_result || ldap_count_entries($ldapconnection, $ldap_result) == 0)  {
                 continue;
             }
 


### PR DESCRIPTION
Hi!

Because the check at line 729 checks only for an invalid/erroneous ldap_search, the loop is left in the next if-statement (line 747) as long as the first LDAP-context does not return a result.
So the authentication works only for the first LDAP-context.

So here is my pull request.

Cheers,
Helge
